### PR TITLE
Session Presence

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,9 @@ module github.com/pion/ion-cluster
 
 go 1.15
 
-// replace github.com/pion/ion-sfu => github.com/billylindeman/ion-sfu  master
-//replace github.com/pion/ion-sfu => github.com/billylindeman/ion-sfu  master
+//replace github.com/pion/ion-sfu => github.com/cryptagon/ion-sfu master-tandem
+replace github.com/pion/ion-sfu => github.com/cryptagon/ion-sfu v1.10.4-0.20210518234538-0fe209599f01
+
 // replace github.com/pion/ion-sfu => /Users/billy/Development/go/src/github.com/pion/ion-sfu
 
 replace google.golang.org/grpc => google.golang.org/grpc v1.26.0

--- a/go.sum
+++ b/go.sum
@@ -179,6 +179,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsr
 github.com/creack/pty v1.1.7 h1:6pwm8kMQKCmgUg0ZHTm5+/YvRK0s3THD/28+T6/kk4A=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
+github.com/cryptagon/ion-sfu v1.10.4-0.20210518234538-0fe209599f01 h1:ETWsbwdhIA9tO52Aa0RH2sELUGBNv7ut4yRJTJ6mSTE=
+github.com/cryptagon/ion-sfu v1.10.4-0.20210518234538-0fe209599f01/go.mod h1:Wx6b4qGUjvSo1kGl+/fHl0ZF48g2IJOjzUFg0yCo9qY=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/pkg/coordinator_etcd.go
+++ b/pkg/coordinator_etcd.go
@@ -25,7 +25,7 @@ type etcdCoordinator struct {
 
 	w             sfu.WebRTCTransportConfig
 	datachannels  []*sfu.Datachannel
-	localSessions map[string]*sfu.SessionLocal
+	localSessions map[string]*Session
 	sessionLeases map[string]context.CancelFunc
 }
 
@@ -55,7 +55,7 @@ func newCoordinatorEtcd(conf RootConfig) (*etcdCoordinator, error) {
 		w:             w,
 		datachannels:  []*sfu.Datachannel{dc},
 		sessionLeases: make(map[string]context.CancelFunc),
-		localSessions: make(map[string]*sfu.SessionLocal),
+		localSessions: make(map[string]*Session),
 	}, nil
 }
 
@@ -145,7 +145,7 @@ func (e *etcdCoordinator) ensureSession(sessionID string) sfu.Session {
 		return s
 	}
 
-	s := sfu.NewSession(sessionID, e.datachannels, e.w).(*sfu.SessionLocal)
+	s := sfu.NewSession(sessionID, e.datachannels, e.w).(*Session)
 	s.OnClose(func() {
 		e.onSessionClosed(sessionID)
 	})

--- a/pkg/server.go
+++ b/pkg/server.go
@@ -104,6 +104,7 @@ func (s *Signal) ServeWebsocket() {
 			sync.Mutex{},
 			s.c,
 			sfu.NewPeer(s.c),
+			"",
 		}
 		defer p.Close()
 

--- a/pkg/session.go
+++ b/pkg/session.go
@@ -71,7 +71,7 @@ func (s *Session) Broadcast(msg Broadcast) {
 	for id, ch := range s.broadcastListeners {
 		select {
 		case ch <- msg:
-			log.V(1).Info("wrote broadcast: %#v", "msg", msg)
+			log.V(4).Info("wrote broadcast", "msg", msg)
 		default:
 			log.Error(nil, "couldn't write broadcast to channel, removing", "id", id)
 			delete(s.broadcastListeners, id)

--- a/pkg/session.go
+++ b/pkg/session.go
@@ -33,14 +33,13 @@ func NewSession(id string, dcs []*sfu.Datachannel, cfg sfu.WebRTCTransportConfig
 
 func (s *Session) UpdatePresenceMetaForPeer(peerID string, meta interface{}) {
 	s.mu.Lock()
-	s.mu.Unlock()
+	defer s.mu.Unlock()
 
+	s.presenceRevision += 1
 	if meta != nil {
 		s.presence[peerID] = meta
-		s.presenceRevision += 1
 	} else {
 		delete(s.presence, peerID)
-		s.presenceRevision += 1
 	}
 
 	msg := Broadcast{

--- a/pkg/session.go
+++ b/pkg/session.go
@@ -1,0 +1,80 @@
+package cluster
+
+import (
+	"sync"
+
+	sfu "github.com/pion/ion-sfu/pkg/sfu"
+)
+
+type Broadcast struct {
+	method string
+	params interface{}
+}
+
+type Session struct {
+	mu               sync.Mutex
+	presence         map[string]interface{}
+	presenceRevision uint64
+
+	broadcastListeners map[string]chan<- Broadcast
+
+	sfu.SessionLocal
+}
+
+func NewSession(id string, dcs []*sfu.Datachannel, cfg sfu.WebRTCTransportConfig) Session {
+	return Session{
+		sync.Mutex{},
+		make(map[string]interface{}),
+		0,
+		make(map[string]chan<- Broadcast),
+		*sfu.NewSession(id, dcs, cfg).(*sfu.SessionLocal),
+	}
+}
+
+func (s *Session) UpdateMetadataForPeer(peerID string, meta interface{}) {
+	s.mu.Lock()
+	s.mu.Unlock()
+
+	if meta != nil {
+		s.presence[peerID] = meta
+		s.presenceRevision += 1
+	} else {
+		delete(s.presence, peerID)
+		s.presenceRevision += 1
+	}
+
+	msg := Broadcast{
+		method: "presence",
+		params: Presence{
+			Revision: s.presenceRevision,
+			Meta:     s.presence,
+		},
+	}
+
+	s.Broadcast(msg)
+}
+
+func (s *Session) BroadcastAddListener(peerID string, ch chan<- Broadcast) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.broadcastListeners[peerID] = ch
+}
+
+func (s *Session) BroadcastRemoveListener(peerID string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.broadcastListeners, peerID)
+}
+
+func (s *Session) Broadcast(msg Broadcast) {
+	for id, ch := range s.broadcastListeners {
+		select {
+		case ch <- msg:
+			log.V(1).Info("wrote broadcast: %#v", "msg", msg)
+		default:
+			log.Error(nil, "couldn't write broadcast to channel, removing", "id", id)
+			delete(s.broadcastListeners, id)
+		}
+	}
+}

--- a/pkg/session.go
+++ b/pkg/session.go
@@ -31,7 +31,7 @@ func NewSession(id string, dcs []*sfu.Datachannel, cfg sfu.WebRTCTransportConfig
 	}
 }
 
-func (s *Session) UpdateMetadataForPeer(peerID string, meta interface{}) {
+func (s *Session) UpdatePresenceMetaForPeer(peerID string, meta interface{}) {
 	s.mu.Lock()
 	s.mu.Unlock()
 


### PR DESCRIPTION
This adds support for storing metadata in every session that will be broadcast out to users on each update.  Every client can now make the rpc call 'presence_set' with a dictionary, and that will be updated for the peer.ID(), and then the entire session dict will be broadcast to all users with an outbound notification 'presence'.

Clients' ability to receive inbound presence will depend on this:
https://github.com/pion/ion-sdk-js/pull/204/files